### PR TITLE
Publishing to MavenLocal

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -49,3 +49,6 @@ publishing{
 }
 
 project.archivesBaseName = 'titan-algorithms-lib'
+
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
This PR adds the ability to publish the `lib` subproject to the local Maven repository through Gradle. This allows the Titan Algorithms lib to be used in another project being built on the same machine.

To publish the compiled jar, the source code jar, and the javadoc to the local Maven repository, simply run `gradle publish`.
The local Maven repository can be configured in the build.gradle file of the consuming project by adding `mavenLocal()` to the `repositories` block. The library is currently published with the groupId `com.titanrobotics2022.titan-algorithms`, the artifactId `titan-algorithms-lib`, and the version `0.0.0`; the necessary dependency is thus `com.titanrobotics2022.titan-algorithms:titan-algorithms-lib:0.0.0`.